### PR TITLE
Update Winget to latest Preview

### DIFF
--- a/Winget-AutoUpdate-Install.ps1
+++ b/Winget-AutoUpdate-Install.ps1
@@ -124,7 +124,7 @@ function Install-WinGet{
     #Check Package Install
     Write-Host "Checking if Winget is installed" -ForegroundColor Yellow
     $TestWinGet = Get-AppxProvisionedPackage -Online | Where-Object {$_.DisplayName -eq "Microsoft.DesktopAppInstaller"}
-    If([Version]$TestWinGet.Version -gt "2022.213.0.0") {
+    If([Version]$TestWinGet.Version -gt "2022.506.16.0") {
 
         Write-Host "WinGet is Installed" -ForegroundColor Green
     
@@ -133,7 +133,7 @@ function Install-WinGet{
 
         #Download WinGet MSIXBundle
         Write-Host "Not installed. Downloading WinGet..."
-        $WinGetURL = "https://github.com/microsoft/winget-cli/releases/download/v1.3.431/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
+        $WinGetURL = "https://github.com/microsoft/winget-cli/releases/download/v1.3.1251-preview/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
         $WebClient=New-Object System.Net.WebClient
         $WebClient.DownloadFile($WinGetURL, "$PSScriptRoot\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle")
 


### PR DESCRIPTION
The latest Winget Preview version (https://github.com/microsoft/winget-cli/releases/tag/v1.3.1251-preview) includes a fix to allow the install of packages from the MSStore without an MSA account. This means that packages like the Company Portal could be installed without requiring the MS Store for Business linked in Intune.